### PR TITLE
fix: load DISCORDJS_APCHANNEL_ID from env and respect loaded monitors

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,48 +12,51 @@ config.DISCORDJS_BOT_TOKEN = process.env.DISCORDJS_BOT_TOKEN;
 config.DISCORDJS_TEXTCHANNEL_ID = process.env.DISCORDJS_TEXTCHANNEL_ID;
 config.DISCORDJS_ADMINCHANNEL_ID = process.env.DISCORDJS_ADMINCHANNEL_ID;
 config.DISCORDJS_ROLE_ID = process.env.DISCORDJS_ROLE_ID;
+config.DISCORDJS_APCHANNEL_ID = process.env.DISCORDJS_APCHANNEL_ID;
 config.SINGLE_RUN = process.env.SINGLE_RUN;
 
-config.monitors = [
-    {
-        name: 'AppleEsim',
-        enabled: true,
-        url: 'https://support.apple.com/en-us/101569',
-        file: './src/apple_esim.json',
-        country: 'Chile',
-    },
-    {
-        name: 'Carrier',
-        enabled: true,
-        url: 'https://s.mzstatic.com/version',
-        file: './src/carriers.json',
-        carriers: [
-            'EntelPCS_cl',
-            'movistar_cl',
-            'Claro_cl',
-            'Nextel_cl'
-        ],
-    },
-    {
-        name: 'AppleFeature',
-        enabled: true,
-        url: 'https://www.apple.com/ios/feature-availability/',
-        file: './src/apple_features.json',
-        keywords: ['chile', 'spanish (latin america)', 'scl'],
-    },
-    {
-        name: 'ApplePay',
-        enabled: true,
-        file: './src/apple_pay_responses.json',
-        configUrl: 'https://smp-device-content.apple.com/static/region/v2/config.json',
-        configAltUrl: 'https://smp-device-content.apple.com/static/region/v2/config-alt.json',
-        region: 'CL',
-    },
-    {
-        name: 'Site',
-        enabled: true,
-        file: './src/sites.json',
-    },
-];
+if (!config.monitors) {
+    config.monitors = [
+        {
+            name: 'AppleEsim',
+            enabled: true,
+            url: 'https://support.apple.com/en-us/101569',
+            file: './src/apple_esim.json',
+            country: 'Chile',
+        },
+        {
+            name: 'Carrier',
+            enabled: true,
+            url: 'https://s.mzstatic.com/version',
+            file: './src/carriers.json',
+            carriers: [
+                'EntelPCS_cl',
+                'movistar_cl',
+                'Claro_cl',
+                'Nextel_cl'
+            ],
+        },
+        {
+            name: 'AppleFeature',
+            enabled: true,
+            url: 'https://www.apple.com/ios/feature-availability/',
+            file: './src/apple_features.json',
+            keywords: ['chile', 'spanish (latin america)', 'scl'],
+        },
+        {
+            name: 'ApplePay',
+            enabled: true,
+            file: './src/apple_pay_responses.json',
+            configUrl: 'https://smp-device-content.apple.com/static/region/v2/config.json',
+            configAltUrl: 'https://smp-device-content.apple.com/static/region/v2/config-alt.json',
+            region: 'CL',
+        },
+        {
+            name: 'Site',
+            enabled: true,
+            file: './src/sites.json',
+        },
+    ];
+}
 
 module.exports = config;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -31,4 +31,26 @@ describe('config', () => {
         const config = require('../src/config');
         expect(config.interval).toBe(10);
     });
+
+    /**
+     * Test case for DISCORDJS_APCHANNEL_ID.
+     */
+    it('should load DISCORDJS_APCHANNEL_ID from env', () => {
+        process.env.DISCORDJS_APCHANNEL_ID = 'ap-channel-id';
+        const storage = require('../src/storage');
+        storage.loadSettings.mockReturnValue({});
+        const config = require('../src/config');
+        expect(config.DISCORDJS_APCHANNEL_ID).toBe('ap-channel-id');
+    });
+
+    /**
+     * Test case ensuring loaded monitors are not overwritten.
+     */
+    it('should prioritize loaded monitors over defaults', () => {
+        const customMonitors = [{ name: 'CustomMonitor', enabled: true }];
+        const storage = require('../src/storage');
+        storage.loadSettings.mockReturnValue({ monitors: customMonitors });
+        const config = require('../src/config');
+        expect(config.monitors).toEqual(customMonitors);
+    });
 });


### PR DESCRIPTION
## Summary
Fixes two configuration issues identified in `src/config.js`:
1. `DISCORDJS_APCHANNEL_ID` was missing the assignment from environment variables.
2. Default monitor configurations were unconditionally overriding settings loaded from `src/settings.json`.

## Changes
*   **src/config.js**: 
    *   Added assignment for `config.DISCORDJS_APCHANNEL_ID` from `process.env`.
    *   Wrapped the default `config.monitors` assignment in a conditional check (`if (!config.monitors)`) to ensure it only applies if no monitors were loaded from storage.
*   **tests/config.test.js**:
    *   Added a test case to verify `DISCORDJS_APCHANNEL_ID` is loaded from the environment.
    *   Added a test case to ensure loaded monitor settings take precedence over defaults.

## Testing
*   **Unit Tests**: `npm test -- tests/config.test.js` passes (new tests included). Full regression suite (`npm test`) passes.
*   **System Test**: `npm start` (Single Run mode) executes successfully, initializing and checking all monitors.