### PR TITLE
ci: add v1.x and v2.x branches to workflow triggers

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v1.x, v2.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v1.x, v2.x ]
   workflow_dispatch:
 
 # If you push multiple times quickly, cancel the old runs to save resources


### PR DESCRIPTION
This PR updates the Node.js CI workflow to include 'v1.x' and 'v2.x' branches in the push and pull_request triggers.