### PR TITLE
fix: resolve ephemeral deprecation warnings and missing JSDoc returns

### DIFF
--- a/__mocks__/discord.js.js
+++ b/__mocks__/discord.js.js
@@ -137,5 +137,8 @@ module.exports = {
       ManageGuild: 1n << 5n,
       Administrator: 1n << 3n,
   },
+  MessageFlags: {
+      Ephemeral: 1n << 6n,
+  },
   Collection: Map,
 };

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -17,7 +17,7 @@ module.exports = {
     async execute(interaction, client, state, config, monitorManager) {
         const siteMonitor = monitorManager.getMonitor('Site');
         if (!siteMonitor) {
-            return interaction.reply({ content: 'Site monitor is not available.', ephemeral: true });
+            return interaction.reply({ content: 'Site monitor is not available.', flags: [MessageFlags.Ephemeral] });
         }
 
         const modal = new ModalBuilder()
@@ -62,10 +62,10 @@ module.exports = {
         try {
             url = new URL(urlString);
             if (!['http:', 'https:'].includes(url.protocol)) {
-                return interaction.reply({ content: 'Invalid protocol. Only HTTP and HTTPS are allowed.', ephemeral: true });
+                return interaction.reply({ content: 'Invalid protocol. Only HTTP and HTTPS are allowed.', flags: [MessageFlags.Ephemeral] });
             }
         } catch (e) {
-            return interaction.reply({ content: 'Invalid URL format.', ephemeral: true });
+            return interaction.reply({ content: 'Invalid URL format.', flags: [MessageFlags.Ephemeral] });
         }
 
         const siteMonitor = monitorManager.getMonitor('Site');

--- a/src/commands/monitor.js
+++ b/src/commands/monitor.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -57,7 +57,7 @@ module.exports = {
         if (targetMonitors.length === 0) {
             return interaction.reply({
                 content: `Monitor "${targetMonitorName}" not found.`, 
-                ephemeral: true 
+                flags: [MessageFlags.Ephemeral] 
             });
         }
 
@@ -87,7 +87,7 @@ module.exports = {
                 const failures = results.filter(r => r.status === 'rejected');
                 if (failures.length > 0) {
                     console.error(`${failures.length} monitor check(s) failed during manual trigger:`, failures);
-                    await interaction.followUp({ content: `Warning: ${failures.length} monitor check(s) failed. See logs for details.`, ephemeral: true });
+                    await interaction.followUp({ content: `Warning: ${failures.length} monitor check(s) failed. See logs for details.`, flags: [MessageFlags.Ephemeral] });
                 }
                 break;
             }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRowBuilder, ComponentType } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRowBuilder, ComponentType, MessageFlags } = require('discord.js');
 
 /**
  * Generates and sends a dropdown menu to select a site for removal.
@@ -9,7 +9,7 @@ const { SlashCommandBuilder, PermissionFlagsBits, StringSelectMenuBuilder, Strin
 async function showRemovalDropdown(interaction, sites) {
     if (sites.length === 0) {
         const content = 'No hay sitios para monitorear. Agrega uno con `/add`.';
-        return interaction.reply({ content, ephemeral: true });
+        return interaction.reply({ content, flags: [MessageFlags.Ephemeral] });
     }
 
     const select = new StringSelectMenuBuilder()
@@ -30,7 +30,7 @@ async function showRemovalDropdown(interaction, sites) {
         content: 'Selecciona el sitio que deseas dejar de monitorear:',
         components: [row],
         embeds: [],
-        ephemeral: true
+        flags: [MessageFlags.Ephemeral]
     };
 
     await interaction.reply(response);
@@ -54,7 +54,7 @@ module.exports = {
         const siteMonitor = monitorManager.getMonitor('Site');
 
         if (!siteMonitor) {
-            return interaction.reply({ content: 'Site monitor is not available.', ephemeral: true });
+            return interaction.reply({ content: 'Site monitor is not available.', flags: [MessageFlags.Ephemeral] });
         }
 
         return showRemovalDropdown(interaction, siteMonitor.state);
@@ -97,7 +97,6 @@ module.exports = {
                 // Send a public confirmation
                 await interaction.followUp({
                     content: `✅ Se ha eliminado **${removedSite.id}** de la lista de monitoreo.`,
-                    ephemeral: false,
                     allowedMentions: { parse: [] }
                 });
             } else {

--- a/src/handlers/interactionHandler.js
+++ b/src/handlers/interactionHandler.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits } = require('discord.js');
+const { PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { loadCommands } = require('../utils/commandLoader');
 
 // Load commands once
@@ -11,7 +11,7 @@ const commands = loadCommands();
  */
 async function handleInteractionError(interaction, error) {
     console.error(`Error handling interaction (${interaction.customId || interaction.commandName}):`, error);
-    const errorMessage = { content: 'There was an error processing this interaction.', ephemeral: true };
+    const errorMessage = { content: 'There was an error processing this interaction.', flags: [MessageFlags.Ephemeral] };
     
     if (interaction.deferred) {
         await interaction.editReply(errorMessage);
@@ -30,6 +30,7 @@ async function handleInteractionError(interaction, error) {
  * @param {object} state The application state.
  * @param {object} config The application configuration.
  * @param {object} monitorManager The MonitorManager instance.
+ * @returns {Promise<void>}
  */
 async function handleInteraction(interaction, client, state, config, monitorManager) {
     // For non-ChatInput interactions (Modals, Components, Autocomplete), 
@@ -39,7 +40,7 @@ async function handleInteraction(interaction, client, state, config, monitorMana
         
         if (!hasPermission) {
             if (interaction.isAutocomplete()) return; // Silent fail for autocomplete
-            return interaction.reply({ content: 'You are not authorized to use this interaction.', ephemeral: true });
+            return interaction.reply({ content: 'You are not authorized to use this interaction.', flags: [MessageFlags.Ephemeral] });
         }
     }
 

--- a/tests/commands/list_remove.test.js
+++ b/tests/commands/list_remove.test.js
@@ -1,6 +1,7 @@
 const listCommand = require('../../src/commands/list');
 const removeCommand = require('../../src/commands/remove');
 const helpCommand = require('../../src/commands/help');
+const { MessageFlags } = require('discord.js');
 
 describe('List, Remove, Help Commands', () => {
     let mockInteraction, mockState, mockClient, mockMonitorManager, mockSiteMonitor;
@@ -63,7 +64,7 @@ describe('List, Remove, Help Commands', () => {
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('Selecciona el sitio'),
                 components: expect.any(Array),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
     });

--- a/tests/commands/remove_interactive.test.js
+++ b/tests/commands/remove_interactive.test.js
@@ -1,5 +1,5 @@
 const removeCommand = require('../../src/commands/remove');
-const { ComponentType } = require('discord.js');
+const { ComponentType, MessageFlags } = require('discord.js');
 
 describe('Remove Command Interactive Features', () => {
     let mockInteraction, mockState, mockClient, mockMonitorManager, mockSiteMonitor;
@@ -42,7 +42,7 @@ describe('Remove Command Interactive Features', () => {
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('Selecciona el sitio'),
                 components: expect.any(Array),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
     });
@@ -53,7 +53,7 @@ describe('Remove Command Interactive Features', () => {
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 components: expect.any(Array),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
 
@@ -75,7 +75,6 @@ describe('Remove Command Interactive Features', () => {
             }));
             expect(mockInteraction.followUp).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('Se ha eliminado **site1**'),
-                ephemeral: false,
                 allowedMentions: { parse: [] }
             }));
         });

--- a/tests/handlers/interactionHandler.test.js
+++ b/tests/handlers/interactionHandler.test.js
@@ -1,4 +1,5 @@
 const { handleInteraction } = require('../../src/handlers/interactionHandler');
+const { MessageFlags } = require('discord.js');
 
 // Mock fs and path to control command loading via commandLoader
 // The handler imports commandLoader. We should mock commandLoader directly.
@@ -146,7 +147,7 @@ describe('Interaction Handler', () => {
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('error processing'),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
 
             // Restore handleModal
@@ -167,7 +168,7 @@ describe('Interaction Handler', () => {
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('error processing'),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
 
@@ -185,7 +186,7 @@ describe('Interaction Handler', () => {
 
             expect(mockInteraction.editReply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('error processing'),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
 
@@ -203,7 +204,7 @@ describe('Interaction Handler', () => {
 
             expect(mockInteraction.followUp).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('error processing'),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
     });
@@ -219,7 +220,7 @@ describe('Interaction Handler', () => {
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('not authorized'),
-                ephemeral: true
+                flags: [MessageFlags.Ephemeral]
             }));
         });
 


### PR DESCRIPTION
This PR addresses the deprecation warning for the `ephemeral` property in Discord interaction responses by transitioning to the `flags` property with `MessageFlags.Ephemeral`. It also fixes a JSDoc linting warning.

### Changes:
- Replaced `ephemeral: true` with `flags: [MessageFlags.Ephemeral]` in:
    - `src/handlers/interactionHandler.js`
    - `src/commands/add.js`
    - `src/commands/monitor.js`
    - `src/commands/remove.js`
- Updated `__mocks__/discord.js.js` to include `MessageFlags.Ephemeral`.
- Updated all relevant tests to verify the use of `flags` instead of `ephemeral`.
- Added missing `@returns` tag to `handleInteraction` in `src/handlers/interactionHandler.js` to resolve a lint warning.