### PR TITLE
fix: prevent settings deletion during tests and silence Node 25 warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/bot.js",
   "scripts": {
-    "test": "jest --silent",
+    "test": "NODE_OPTIONS='--no-warnings' jest --silent",
     "start": "node ./src/bot.js",
     "dev": "nodemon ./src/bot.js",
     "lint": "eslint .",

--- a/tests/storage_security.test.js
+++ b/tests/storage_security.test.js
@@ -1,19 +1,11 @@
 const fs = require('fs-extra');
 const { saveSettings, SENSITIVE_SETTINGS_KEYS } = require('../src/storage');
 
-const SETTINGS_FILE = './config/settings.json';
+jest.mock('fs-extra');
 
 describe('saveSettings', () => {
-    beforeAll(() => {
-        // Ensure config dir exists
-        fs.ensureDirSync('./config');
-    });
-
-    afterEach(() => {
-        // Clean up
-        if (fs.existsSync(SETTINGS_FILE)) {
-            fs.unlinkSync(SETTINGS_FILE);
-        }
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
     it('should exclude sensitive environment variables from settings.json', async () => {
@@ -28,7 +20,11 @@ describe('saveSettings', () => {
 
         await saveSettings(sensitiveSettings);
 
-        const savedContent = fs.readJSONSync(SETTINGS_FILE);
+        // Check that fs.outputJSON was called
+        expect(fs.outputJSON).toHaveBeenCalled();
+        
+        // Get the saved content from the first call's second argument
+        const savedContent = fs.outputJSON.mock.calls[0][1];
 
         expect(savedContent).toHaveProperty('interval', 10);
         


### PR DESCRIPTION
This PR addresses two issues in the test environment:
1. **Settings Deletion**: Fixed a bug in `tests/storage_security.test.js` where the real `config/settings.json` was being deleted during test cleanup. The test now uses `jest.mock('fs-extra')` to avoid file system interaction.
2. **Node 25 Warnings**: Silenced the experimental Web Storage warning (`--localstorage-file`) triggered by Node 25/Jest 30 by adding `NODE_OPTIONS='--no-warnings'` to the test script.