### PR TITLE
feat: make help command response ephemeral

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -22,6 +22,6 @@ module.exports = {
             ])
             .setFooter({ text: 'Tip: ¡Usa el autocompletado para los nombres de los monitores!' });
 
-        await interaction.reply({ embeds: [embed] });
+        await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
     },
 };

--- a/tests/commands/list_remove.test.js
+++ b/tests/commands/list_remove.test.js
@@ -73,7 +73,8 @@ describe('List, Remove, Help Commands', () => {
         it('should show help embed', async () => {
             await helpCommand.execute(mockInteraction);
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
-                embeds: expect.any(Array)
+                embeds: expect.any(Array),
+                flags: [MessageFlags.Ephemeral]
             }));
         });
     });


### PR DESCRIPTION
Updates the `/help` command to use `MessageFlags.Ephemeral` so that its response is only visible to the user who invoked it. This aligns with standard Discord bot practices and reduces channel clutter.

- Modified `src/commands/help.js` to include `MessageFlags` and set the response flag.
- Updated `tests/commands/list_remove.test.js` to verify the ephemeral flag in tests.