### PR TITLE
Refactor: Centralize Site State in SiteMonitor

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -89,8 +89,7 @@ module.exports = {
         try {
             const { site, warning } = await siteMonitor.addSite(urlString, selector, force);
 
-            // Update local state to match the monitor's state (which is the source of truth)
-            state.sitesToMonitor = siteMonitor.state;
+            // Local state update removed. SiteMonitor is the source of truth.
             
             let warningMessage = '';
             if (warning) {

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -12,14 +12,18 @@ module.exports = {
      * @param {import('discord.js').ChatInputCommandInteraction} interaction The interaction object.
      * @param {import('discord.js').Client} client The Discord client.
      * @param {object} state The state of the bot.
+     * @param {object} config The config object.
+     * @param {import('../MonitorManager')} monitorManager The MonitorManager instance.
      * @returns {Promise<void>}
      */
-    async execute(interaction, client, state) {
-        if (state.sitesToMonitor.length < 1) {
+    async execute(interaction, client, state, config, monitorManager) {
+        const siteMonitor = monitorManager.getMonitor('Site');
+        const sites = siteMonitor ? siteMonitor.state : [];
+
+        if (sites.length < 1) {
             return interaction.reply('No hay sitios siendo monitoreados. Agrega uno con `/add`.');
         }
 
-        const sites = state.sitesToMonitor;
         const siteCount = sites.length;
         const CHUNK_SIZE = 25;
 

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -88,7 +88,7 @@ module.exports = {
             const removedSite = await siteMonitor.removeSiteByIndex(index);
 
             if (removedSite) {
-                state.sitesToMonitor = siteMonitor.state;
+                // Local state update removed. SiteMonitor is the source of truth.
                 // Update the ephemeral message to clear components
                 await interaction.update({ 
                     content: `Eliminando **${sanitizeMarkdown(removedSite.id)}**...`, 

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -11,9 +11,11 @@ module.exports = {
      * @param {import('discord.js').ChatInputCommandInteraction} interaction The interaction object.
      * @param {import('discord.js').Client} client The Discord client.
      * @param {object} state The state object.
+     * @param {object} config The config object.
+     * @param {import('../MonitorManager')} monitorManager The MonitorManager instance.
      * @returns {Promise<void>}
      */
-    async execute(interaction, client, state) {
-        await listCommand.execute(interaction, client, state);
+    async execute(interaction, client, state, config, monitorManager) {
+        await listCommand.execute(interaction, client, state, config, monitorManager);
     },
 };

--- a/src/state.js
+++ b/src/state.js
@@ -6,16 +6,14 @@
 const storage = require('./storage');
 
 const state = {
-    sitesToMonitor: [],
     settings: { interval: 5 },
     responses: [],
 
     /**
-     * Loads sites to monitor, settings, and responses from storage.
+     * Loads settings and responses from storage.
      * @returns {void}
      */
     load() {
-        this.sitesToMonitor = storage.loadSites();
         this.settings = storage.loadSettings();
         this.responses = storage.loadResponses();
     },

--- a/tests/commands/add.test.js
+++ b/tests/commands/add.test.js
@@ -93,8 +93,6 @@ describe('add command', () => {
 
             expect(mockMonitorManager.getMonitor).toHaveBeenCalledWith('Site');
             expect(mockSiteMonitor.addSite).toHaveBeenCalledWith('https://example.com', '#test', false);
-            expect(mockState.sitesToMonitor).toHaveLength(1);
-            expect(mockState.sitesToMonitor[0].url).toBe('https://example.com');
             
             expect(mockInteraction.deferReply).toHaveBeenCalled();
             expect(mockInteraction.editReply).toHaveBeenCalledWith(expect.objectContaining({

--- a/tests/commands/list_remove.test.js
+++ b/tests/commands/list_remove.test.js
@@ -41,7 +41,7 @@ describe('List, Remove, Help Commands', () => {
 
     describe('/list', () => {
         it('should show list of sites', async () => {
-            await listCommand.execute(mockInteraction, mockClient, mockState);
+            await listCommand.execute(mockInteraction, mockClient, mockState, {}, mockMonitorManager);
 
             expect(mockInteraction.deferReply).toHaveBeenCalled();
             expect(mockInteraction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -51,8 +51,8 @@ describe('List, Remove, Help Commands', () => {
         });
 
         it('should message if no sites', async () => {
-            mockState.sitesToMonitor = [];
-            await listCommand.execute(mockInteraction, mockClient, mockState);
+            mockSiteMonitor.state = [];
+            await listCommand.execute(mockInteraction, mockClient, mockState, {}, mockMonitorManager);
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.stringContaining('No hay sitios'));
         });
     });

--- a/tests/commands/remove_interactive.test.js
+++ b/tests/commands/remove_interactive.test.js
@@ -68,7 +68,7 @@ describe('Remove Command Interactive Features', () => {
             await removeCommand.handleComponent(mockInteraction, mockClient, mockState, {}, mockMonitorManager, 'select');
 
             expect(mockSiteMonitor.removeSiteByIndex).toHaveBeenCalledWith(0);
-            expect(mockState.sitesToMonitor).toEqual([{ id: 'site2', url: 'http://site2.com' }]);
+            
             expect(mockInteraction.update).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('Eliminando **site1**'),
                 components: []

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -26,17 +26,14 @@ describe('state', () => {
      * Test case for loading sites, settings, and responses from storage.
      */
     it('should load sites, settings, and responses from storage', () => {
-        const mockSites = [{ id: 'test' }];
         const mockSettings = { interval: 10 };
         const mockResponses = [{ trigger: 'test' }];
 
-        storage.loadSites.mockReturnValue(mockSites);
         storage.loadSettings.mockReturnValue(mockSettings);
         storage.loadResponses.mockReturnValue(mockResponses);
 
         state.load();
 
-        expect(state.sitesToMonitor).toEqual(mockSites);
         expect(state.settings).toEqual(mockSettings);
         expect(state.responses).toEqual(mockResponses);
     });


### PR DESCRIPTION
## Description
This PR addresses issue #38 by centralizing the source of truth for monitored sites within the `SiteMonitor` class, eliminating the duplicated state in `state.sitesToMonitor`.

## Changes
- **Commands**: Updated `add`, `remove`, `list`, and `show` to fetch site data directly from `MonitorManager.getMonitor('Site')`.
- **State**: Removed `sitesToMonitor` property and loading logic from `src/state.js`.
- **Tests**: Updated unit tests for commands and state to reflect these architectural changes.

## Fixes
- Closes #38