### PR TITLE
Refactor: Deduplicate SiteMonitor Tests

### DIFF
--- a/__mocks__/crypto.js
+++ b/__mocks__/crypto.js
@@ -1,0 +1,12 @@
+const mockUpdate = jest.fn().mockReturnThis();
+const mockDigest = jest.fn().mockReturnValue('mock-hash');
+
+module.exports = {
+    createHash: jest.fn(() => ({
+        update: mockUpdate,
+        digest: mockDigest,
+    })),
+    // Expose spies for assertion
+    _mockUpdate: mockUpdate,
+    _mockDigest: mockDigest
+};

--- a/__mocks__/diff.js
+++ b/__mocks__/diff.js
@@ -1,0 +1,3 @@
+module.exports = {
+    diffLines: jest.fn()
+};

--- a/__mocks__/got.js
+++ b/__mocks__/got.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/__mocks__/jsdom.js
+++ b/__mocks__/jsdom.js
@@ -1,0 +1,15 @@
+const actualJsdom = jest.requireActual('jsdom');
+
+const JSDOM = jest.fn((html) => {
+    const actualDom = new actualJsdom.JSDOM(html);
+    return {
+        window: {
+            document: {
+                querySelector: jest.fn((selector) => actualDom.window.document.querySelector(selector)),
+                title: actualDom.window.document.title,
+            },
+        },
+    };
+});
+
+module.exports = { JSDOM };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig([
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
   // Jest configuration for test files
   {
-    files: ["**/*.test.js"],
+    files: ["**/*.test.js", "**/__mocks__/**/*.{js,mjs,cjs}"],
     ...jest.configs["flat/recommended"],
     languageOptions: {
       globals: {

--- a/src/__mocks__/config.js
+++ b/src/__mocks__/config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    DISCORDJS_TEXTCHANNEL_ID: 'mockChannelId',
+    interval: 5,
+    monitors: [],
+    channels: []
+};

--- a/src/__mocks__/storage.js
+++ b/src/__mocks__/storage.js
@@ -1,0 +1,13 @@
+module.exports = {
+    read: jest.fn(),
+    write: jest.fn(),
+    loadSettings: jest.fn().mockReturnValue({
+        interval: 5,
+        debug: false,
+    }),
+    loadSites: jest.fn(),
+    loadResponses: jest.fn(),
+    migrateLegacyData: jest.fn(),
+    saveSettings: jest.fn(),
+    SENSITIVE_SETTINGS_KEYS: [],
+};

--- a/tests/site-monitor-migration.test.js
+++ b/tests/site-monitor-migration.test.js
@@ -1,85 +1,34 @@
-
 const SiteMonitor = require('../src/monitors/SiteMonitor');
 const Discord = require('discord.js');
 const got = require('got');
 const storage = require('../src/storage');
 const crypto = require('crypto');
 
-// Mocks
-jest.mock('../src/storage', () => ({
-    read: jest.fn(),
-    write: jest.fn(),
-    loadSettings: jest.fn().mockReturnValue({
-        interval: 5,
-        debug: false,
-    }),
-}));
-
-jest.mock('../src/config', () => ({
-    DISCORDJS_TEXTCHANNEL_ID: 'mockChannelId',
-    interval: 5,
-}));
-
+// Use manual mocks
+jest.mock('discord.js');
 jest.mock('got');
-
-jest.mock('jsdom', () => {
-    return {
-        JSDOM: jest.fn((html) => {
-            const actualDom = new (jest.requireActual('jsdom').JSDOM)(html);
-            return {
-                window: {
-                    document: {
-                        querySelector: jest.fn((selector) => actualDom.window.document.querySelector(selector)),
-                        title: actualDom.window.document.title,
-                    },
-                },
-            };
-        }),
-    };
-});
-
-jest.mock('crypto', () => {
-    const mockUpdate = jest.fn().mockReturnThis();
-    const mockDigest = jest.fn().mockReturnValue('mock-hash');
-    return {
-        createHash: jest.fn(() => ({
-            update: mockUpdate,
-            digest: mockDigest,
-        })),
-    };
-});
-
-jest.mock('diff', () => ({
-    diffLines: jest.fn(),
-}));
+jest.mock('jsdom');
+jest.mock('crypto');
+jest.mock('diff');
+jest.mock('../src/storage');
+jest.mock('../src/config');
 
 describe('SiteMonitor Migration and ID Update', () => {
     let client;
     let siteMonitor;
-    let mockChannelSend;
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockChannelSend = jest.fn();
-        const mockChannel = { send: mockChannelSend };
-
-        jest.spyOn(Discord, 'Client').mockImplementation(() => ({
-            channels: {
-                cache: {
-                    get: jest.fn(() => mockChannel),
-                },
-            },
-        }));
-
-        jest.spyOn(Discord, 'EmbedBuilder').mockImplementation(() => ({
-             setTitle: jest.fn().mockReturnThis(),
-             addFields: jest.fn().mockReturnThis(),
-             setColor: jest.fn().mockReturnThis(),
-        }));
-
+        
         client = new Discord.Client();
+        // mockChannel = client.channels.cache.get('mockChannelId'); // Unused
+
+        storage.read.mockClear();
+        storage.write.mockClear();
+
         const monitorConfig = { file: 'sites.json' };
         siteMonitor = new SiteMonitor('site-monitor', monitorConfig);
+        siteMonitor.client = client;
     });
 
     it('addSite should use page title as ID', async () => {
@@ -116,9 +65,9 @@ describe('SiteMonitor Migration and ID Update', () => {
         const html = '<html><head><title>Updated Title</title></head><body>Content</body></html>';
         got.mockResolvedValue({ body: html });
         // Same content hash to avoid notification trigger logic
-        crypto.createHash().digest.mockReturnValue('mock-hash'); 
+        crypto._mockDigest.mockReturnValue('mock-hash'); 
 
-        await siteMonitor.check(client);
+        await siteMonitor.check();
 
         expect(siteMonitor.state[0].id).toBe('Updated Title');
         expect(storage.write).toHaveBeenCalledWith('sites.json', siteMonitor.state);
@@ -138,9 +87,9 @@ describe('SiteMonitor Migration and ID Update', () => {
 
         const html = '<html><head></head><body>Content</body></html>';
         got.mockResolvedValue({ body: html });
-        crypto.createHash().digest.mockReturnValue('mock-hash');
+        crypto._mockDigest.mockReturnValue('mock-hash');
 
-        await siteMonitor.check(client);
+        await siteMonitor.check();
 
         expect(siteMonitor.state[0].id).toBe('example.com');
     });


### PR DESCRIPTION
## Description
This PR addresses issue #42 by refactoring the `SiteMonitor` tests to reduce duplication and improve maintainability.

## Changes
- **Shared Mocks**: Extracted common manual mocks (got, jsdom, crypto, diff, storage, config) into `__mocks__` and `src/__mocks__`.
- **Test Refactor**: Updated `tests/site-monitor.test.js` and `tests/site-monitor-migration.test.js` to use these shared mocks instead of inline `jest.mock` implementations.
- **Config**: Updated `eslint.config.mjs` to apply Jest environment globals to mock files.

## Fixes
- Closes #42