### PR TITLE
Feat: Translate remaining UI strings to Spanish

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -109,7 +109,7 @@ module.exports = {
             await interaction.editReply({ embeds: [embed] });
         } catch (error) {
             console.error('Error adding site:', error);
-            await interaction.editReply({ content: `Error adding site: ${error.message}` });
+            await interaction.editReply({ content: `Error al agregar el sitio: ${error.message}` });
         }
     }
 };

--- a/src/commands/monitor.js
+++ b/src/commands/monitor.js
@@ -56,7 +56,7 @@ module.exports = {
 
         if (targetMonitors.length === 0) {
             return interaction.reply({
-                content: `Monitor "${targetMonitorName}" not found.`, 
+                content: `No se encontró el monitor "${targetMonitorName}".`, 
                 flags: [MessageFlags.Ephemeral] 
             });
         }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -55,7 +55,7 @@ module.exports = {
         const siteMonitor = monitorManager.getMonitor('Site');
 
         if (!siteMonitor) {
-            return interaction.reply({ content: 'Site monitor is not available.', flags: [MessageFlags.Ephemeral] });
+            return interaction.reply({ content: 'El monitor de sitios no está disponible.', flags: [MessageFlags.Ephemeral] });
         }
 
         return showRemovalDropdown(interaction, siteMonitor.state);

--- a/src/handlers/interactionHandler.js
+++ b/src/handlers/interactionHandler.js
@@ -11,7 +11,7 @@ const commands = loadCommands();
  */
 async function handleInteractionError(interaction, error) {
     console.error(`Error handling interaction (${interaction.customId || interaction.commandName}):`, error);
-    const errorMessage = { content: 'There was an error processing this interaction.', flags: [MessageFlags.Ephemeral] };
+    const errorMessage = { content: 'Hubo un error al procesar esta interacción.', flags: [MessageFlags.Ephemeral] };
     
     if (interaction.deferred) {
         await interaction.editReply(errorMessage);
@@ -40,7 +40,7 @@ async function handleInteraction(interaction, client, state, config, monitorMana
         
         if (!hasPermission) {
             if (interaction.isAutocomplete()) return; // Silent fail for autocomplete
-            return interaction.reply({ content: 'You are not authorized to use this interaction.', flags: [MessageFlags.Ephemeral] });
+            return interaction.reply({ content: 'No estás autorizado para usar esta interacción.', flags: [MessageFlags.Ephemeral] });
         }
     }
 

--- a/tests/handlers/interactionHandler.test.js
+++ b/tests/handlers/interactionHandler.test.js
@@ -20,8 +20,9 @@ jest.mock('../../src/commands/add.js', () => ({
     data: { name: 'add' },
     execute: jest.fn(),
     handleModal: jest.fn(),
+    handleComponent: jest.fn(),
     autocomplete: jest.fn()
-}), { virtual: true });
+}));
 
 describe('Interaction Handler', () => {
     let mockInteraction, mockConfig, mockClient, mockState, mockMonitorManager;
@@ -29,6 +30,12 @@ describe('Interaction Handler', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         
+        // Ensure add.js mock methods are present (in case they were deleted by a test)
+        const addCommand = require('../../src/commands/add.js');
+        if (!addCommand.handleModal) {
+            addCommand.handleModal = jest.fn();
+        }
+
         mockConfig = {};
 
         mockInteraction = {
@@ -139,14 +146,14 @@ describe('Interaction Handler', () => {
             mockInteraction.customId = 'add:submit';
 
             const addCommand = require('../../src/commands/add.js');
-            // Temporarily remove handleModal
+            // Mock handleModal to be undefined
             const originalHandleModal = addCommand.handleModal;
-            delete addCommand.handleModal;
+            addCommand.handleModal = undefined;
             
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing'),
+                content: expect.stringContaining('error al procesar'),
                 flags: [MessageFlags.Ephemeral]
             }));
 
@@ -167,7 +174,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing'),
+                content: expect.stringContaining('error al procesar'),
                 flags: [MessageFlags.Ephemeral]
             }));
         });
@@ -185,7 +192,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing'),
+                content: expect.stringContaining('error al procesar'),
                 flags: [MessageFlags.Ephemeral]
             }));
         });
@@ -203,7 +210,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.followUp).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing'),
+                content: expect.stringContaining('error al procesar'),
                 flags: [MessageFlags.Ephemeral]
             }));
         });
@@ -219,7 +226,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('not authorized'),
+                content: expect.stringContaining('No estás autorizado'),
                 flags: [MessageFlags.Ephemeral]
             }));
         });
@@ -244,7 +251,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.reply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing')
+                content: expect.stringContaining('error al procesar')
             }));
         });
 
@@ -257,7 +264,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing')
+                content: expect.stringContaining('error al procesar')
             }));
         });
 
@@ -270,7 +277,7 @@ describe('Interaction Handler', () => {
             await handleInteraction(mockInteraction, mockClient, mockState, mockConfig, mockMonitorManager);
 
             expect(mockInteraction.followUp).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('error processing')
+                content: expect.stringContaining('error al procesar')
             }));
         });
     });


### PR DESCRIPTION
## Description
This PR completes the translation of UI strings to Spanish across various commands and handlers to ensure language consistency throughout the bot.

## Changes
- **Commands**: Translated strings in `monitor.js`, `remove.js`, and `add.js`.
- **Handlers**: Translated error and permission messages in `interactionHandler.js`.
- **Tests**: Updated `interactionHandler.test.js` expectations to match the new Spanish strings and improved mock isolation.

## Fixes
- Closes #64