### PR TITLE
Refactor: Fallback image download in DealMonitor

### DIFF
--- a/src/monitors/DealMonitor.js
+++ b/src/monitors/DealMonitor.js
@@ -446,24 +446,21 @@ class DealMonitor extends Monitor {
                     await new Promise((resolve, reject) => {
                         stream.on('response', (res) => {
                             contentType = res.headers['content-type'];
-                            const pureType = contentType ? contentType.split(';')[0].trim() : null;
-                            
                             // Early reject for definitely non-image types
+                            const pureType = contentType ? contentType.split(';')[0].trim() : null;
                             const isPotentiallyImage = !pureType || 
                                                        pureType === 'application/octet-stream' || 
                                                        pureType.startsWith('image/');
                             
                             if (!isPotentiallyImage) {
-                                stream.destroy();
-                                reject(new Error('Resource is definitely not an image'));
+                                stream.destroy(new Error('Resource is definitely not an image'));
                             }
                         });
                         
                         stream.on('data', (chunk) => {
                             receivedLength += chunk.length;
                             if (receivedLength > MAX_IMAGE_SIZE) {
-                                stream.destroy();
-                                reject(new Error('Image too large'));
+                                stream.destroy(new Error('Image too large'));
                             } else {
                                 chunks.push(chunk);
                             }


### PR DESCRIPTION
Implements a fallback mechanism in DealMonitor to download and attach product images directly when a valid external URL is not available. This ensures that Discord embeds always display an image, even if the source URL is problematic or blocked.

- Refactored 'solotodo' imports for better mockability.
- Added logic to download images using 'got' and attach them using 'AttachmentBuilder'.
- **Improved**: Uses 'Content-Type' header and **binary content sniffing** (magic numbers) to correctly determine file extension and validate image types. This allows supporting generic 'application/octet-stream' headers (used by Solotodo) while maintaining security.
- **Security**: Implements a 5MB response size limit using streams and strictly validates image formats (JPEG, PNG, WebP, GIF) via allow-list and binary content to prevent potential Denial of Service (OOM) and Malware Relay (e.g., SVG/HTML/Scripts).
- **Refactored**: Streamlined error handling using 'stream.destroy(error)' and extracted common test logic into hooks (DRY).
- Added comprehensive tests for the new fallback logic, security limits, and binary sniffing.