### PR TITLE
refactor(monitors): move status text and date to embed description in DealMonitor

### DIFF
--- a/src/monitors/DealMonitor.js
+++ b/src/monitors/DealMonitor.js
@@ -357,24 +357,24 @@ class DealMonitor extends Monitor {
         let triggerDate = date;
 
         if (bothNewLow) {
-            statusText = '📉 **Nuevos mínimos históricos**';
+            statusText = 'Nuevos mínimos históricos';
             color = 0x2ecc71;
         } else if (bothBackToLow) {
-            statusText = '🔄 **Volvió a precios históricos**';
+            statusText = 'Volvió a precios históricos';
             showDate = true;
             triggerDate = stored?.minOfferDate; // Use one of them
         } else if (triggers.length > 1) {
             // Mixed triggers (e.g. one is NEW_LOW, other is BACK_TO_LOW)
-            statusText = '📉🔄 **Nuevos precios históricos**';
+            statusText = 'Nuevos precios históricos';
             color = 0x2ecc71;
         } else {
             // Individual triggers
             const type = triggers[0];
             const notificationConfig = {
-                'NEW_LOW_OFFER': { text: '📉 **Nuevo mínimo histórico (con Tarjeta)**', color: 0x2ecc71 },
-                'BACK_TO_LOW_OFFER': { text: '🔄 **Volvió al mínimo histórico (con Tarjeta)**', showDate: true, date: stored?.minOfferDate },
-                'NEW_LOW_NORMAL': { text: '📉 **Nuevo mínimo histórico (todo medio de pago)**', color: 0x27ae60 },
-                'BACK_TO_LOW_NORMAL': { text: '🔄 **Volvió al mínimo histórico (todo medio de pago)**', showDate: true, date: stored?.minNormalDate }
+                'NEW_LOW_OFFER': { text: 'Nuevo mínimo histórico (con Tarjeta)', color: 0x2ecc71 },
+                'BACK_TO_LOW_OFFER': { text: 'Volvió al mínimo histórico (con Tarjeta)', showDate: true, date: stored?.minOfferDate },
+                'NEW_LOW_NORMAL': { text: 'Nuevo mínimo histórico (todo medio de pago)', color: 0x27ae60 },
+                'BACK_TO_LOW_NORMAL': { text: 'Volvió al mínimo histórico (todo medio de pago)', showDate: true, date: stored?.minNormalDate }
             };
             const details = notificationConfig[type];
             statusText = details?.text || '';
@@ -402,10 +402,15 @@ class DealMonitor extends Monitor {
         // drop is likely only available with a mobile plan or is an error.
         if (!bestEntity) return;
 
+        let description = `[${statusText}](${productUrl})`;
+        if (showDate && triggerDate) {
+            description += ` de ${formatDiscordTimestamp(triggerDate)}`;
+        }
+
         const embed = new Discord.EmbedBuilder()
             .setTitle(title)
             //.setURL(productUrl)
-            .setDescription(`${statusText}\n[Solotodo](${productUrl})`)
+            .setDescription(description)
 
             .addFields([
                 { name: '💳 Precio Tarjeta', value: `${formatCLP(product.offerPrice)}`, inline: true },
@@ -413,10 +418,6 @@ class DealMonitor extends Monitor {
             ])
             .setColor(color)
             .setTimestamp();
-
-        if (showDate && triggerDate) {
-            embed.addFields([{ name: '🕒 Precio visto por última vez', value: formatDiscordTimestamp(triggerDate), inline: false }]);
-        }
 
         if (bestEntity.external_url) {
             const storeName = storeMap.get(bestEntity.store) || 'Tienda';

--- a/tests/monitors/DealMonitor.test.js
+++ b/tests/monitors/DealMonitor.test.js
@@ -106,7 +106,7 @@ describe('DealMonitor', () => {
         const sendCall = mockChannel.send.mock.calls[0][0];
         const embed = sendCall.embeds[0];
         expect(embed.data.title).toBe('iPhone');
-        expect(embed.data.description).toContain('**Nuevo mínimo histórico (con Tarjeta)**');
+        expect(embed.data.description).toBe('[Nuevo mínimo histórico (con Tarjeta)](https://www.solotodo.cl/products/1-slug)');
         
         expect(monitor.state['1'].minOfferPrice).toBe(450000);
         expect(monitor.state['1'].minOfferDate).not.toBe('2025-01-01T00:00:00.000Z');
@@ -156,7 +156,7 @@ describe('DealMonitor', () => {
         const sendCall = mockChannel.send.mock.calls[0][0];
         const embed = sendCall.embeds[0];
         expect(embed.data.title).toBe('iPhone');
-        expect(embed.data.description).toContain('**Nuevo mínimo histórico (todo medio de pago)**');
+        expect(embed.data.description).toBe('[Nuevo mínimo histórico (todo medio de pago)](https://www.solotodo.cl/products/1-slug)');
         
         expect(monitor.state['1'].minNormalPrice).toBe(550000);
         expect(monitor.state['1'].minNormalDate).not.toBe('2025-01-01T00:00:00.000Z');
@@ -209,11 +209,11 @@ describe('DealMonitor', () => {
         const sendCall = mockChannel.send.mock.calls[0][0];
         const embed = sendCall.embeds[0];
         expect(embed.data.title).toBe('iPhone');
-        expect(embed.data.description).toContain('**Volvió al mínimo histórico (con Tarjeta)**');
+        // Unix for 2024-12-01T10:00:00Z is 1733047200
+        expect(embed.data.description).toBe('[Volvió al mínimo histórico (con Tarjeta)](https://www.solotodo.cl/products/1-slug) de <t:1733047200:R>');
         
         const dateField = embed.data.fields.find(f => f.name === '🕒 Precio visto por última vez');
-        expect(dateField).toBeDefined();
-        expect(dateField.value).toContain('1733047200'); // Unix for 2024-12-01T10:00:00Z
+        expect(dateField).toBeUndefined();
 
         expect(monitor.state['1'].lastOfferPrice).toBe(10000);
     });
@@ -303,7 +303,7 @@ describe('DealMonitor', () => {
         const sendCall = mockChannel.send.mock.calls[0][0];
         const embed = sendCall.embeds[0];
         expect(embed.data.title).toBe('iPhone');
-        expect(embed.data.description).toContain('**Nuevos mínimos históricos**');
+        expect(embed.data.description).toBe('[Nuevos mínimos históricos](https://www.solotodo.cl/products/1-slug)');
     });
 
     it('should correctly parse products with multiple currencies and pick CLP', async () => {


### PR DESCRIPTION
Moved the deal status text and relative date from the title and fields to the embed description. 

**Changes:**
- Title now only contains the product name.
- Description contains the status text (unbolded, no emojis) as a masked link to Solotodo.
- Relative date is appended to the description link (e.g., '... de hace 2 días').
- Removed separate '🕒 Precio visto por última vez' field.
- Enabled title URL (commented out per latest instruction).