### PR TITLE
feat: unify text and image responses in QAChannel

### DIFF
--- a/src/channels/QAChannel.js
+++ b/src/channels/QAChannel.js
@@ -26,13 +26,17 @@ class QAChannel extends ChannelHandler {
                 const reply_id = Math.floor(Math.random() * response.replies.length);
                 const reply = response.replies[reply_id];
 
+                const responsePayload = {};
                 if (reply.img_response !== "") {
-                    const img = new Discord.AttachmentBuilder(reply.img_response);
-                    message.channel.send({ files: [img] });
+                    responsePayload.files = [new Discord.AttachmentBuilder(reply.img_response)];
                 }
 
                 if (reply.text_response !== "") {
-                    message.reply(reply.text_response);
+                    responsePayload.content = reply.text_response;
+                }
+
+                if (Object.keys(responsePayload).length > 0) {
+                    await message.reply(responsePayload);
                 }
 
                 return true;

--- a/tests/channels/qa.test.js
+++ b/tests/channels/qa.test.js
@@ -40,10 +40,29 @@ describe('QAChannel', () => {
         };
     });
 
-    it('should handle matching message in correct channel', async () => {
+    it('should handle matching message in correct channel (text only)', async () => {
         const handled = await handler.handle(mockMessage, mockState, mockConfig);
         expect(handled).toBe(true);
-        expect(mockMessage.reply).toHaveBeenCalledWith('mundo');
+        expect(mockMessage.reply).toHaveBeenCalledWith({ content: 'mundo' });
+    });
+
+    it('should handle image responses', async () => {
+        mockState.responses[0].replies[0] = { text_response: '', img_response: 'image.png' };
+        const handled = await handler.handle(mockMessage, mockState, mockConfig);
+        expect(handled).toBe(true);
+        expect(mockMessage.reply).toHaveBeenCalledWith(expect.objectContaining({
+            files: expect.any(Array)
+        }));
+    });
+
+    it('should handle combined text and image responses', async () => {
+        mockState.responses[0].replies[0] = { text_response: 'mundo', img_response: 'image.png' };
+        const handled = await handler.handle(mockMessage, mockState, mockConfig);
+        expect(handled).toBe(true);
+        expect(mockMessage.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: 'mundo',
+            files: expect.any(Array)
+        }));
     });
 
     it('should process bot message if ignoreBots is false', async () => {


### PR DESCRIPTION
Modified QAChannel to send both text and image in a single reply when both are present, using Discord.js v14 features.