### PR TITLE
fix: explicit logging for missing 'Send Messages' permission

### DIFF
--- a/src/monitors/SiteMonitor.js
+++ b/src/monitors/SiteMonitor.js
@@ -306,7 +306,7 @@ class SiteMonitor extends Monitor {
                     await channel.send(`¡Cambio detectado en ${sanitizeMarkdown(title)}! 🐸\n${sanitizeMarkdown(site.url)}\n(No tengo permisos para enviar embeds en este canal)`);
                 } catch (fallbackError) {
                     if (fallbackError.code === Discord.RESTJSONErrorCodes.MissingPermissions) {
-                        console.error(`[SiteMonitor] CRITICAL: Missing 'Send Messages' permission in ${channel.name} (${channel.id}). Cannot send ANY notification.`);
+                        console.error(`[SiteMonitor] CRITICAL: Missing 'Send Messages' permission in ${channel.name} (${channel.id}). Cannot send ANY notification.`, fallbackError);
                     } else {
                         console.error(`[SiteMonitor] Failed to send fallback message in ${channel.name} (${channel.id}):`, fallbackError);
                     }

--- a/tests/site-monitor.test.js
+++ b/tests/site-monitor.test.js
@@ -298,7 +298,7 @@ describe('SiteMonitor', () => {
             diff.diffLines.mockReturnValue([]);
 
             const error = new Error('Missing Permissions');
-            error.code = 50013;
+            error.code = Discord.RESTJSONErrorCodes.MissingPermissions;
             
             mockChannel.send
                 .mockRejectedValueOnce(error) // Embed fails
@@ -311,7 +311,7 @@ describe('SiteMonitor', () => {
 
             expect(mockChannel.send).toHaveBeenCalledTimes(2);
             expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Missing permissions to send embed'));
-            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("CRITICAL: Missing 'Send Messages' permission"));
+            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("CRITICAL: Missing 'Send Messages' permission"), error);
 
             consoleWarnSpy.mockRestore();
             consoleErrorSpy.mockRestore();


### PR DESCRIPTION
Enhances the permission error handling. If the fallback text message *also* fails with 50013, it logs a specific CRITICAL error indicating that the bot lacks 'Send Messages' permission entirely for that channel, helping users diagnose channel override issues.