### PR TITLE
refactor(image): extract image processing to utility

### DIFF
--- a/src/monitors/DealMonitor.js
+++ b/src/monitors/DealMonitor.js
@@ -6,43 +6,11 @@ const { formatCLP, sanitizeLinkText, formatDiscordTimestamp } = require('../util
 const solotodo = require('../utils/solotodo');
 const { sleep } = require('../utils/helpers');
 const { getSafeGotOptions } = require('../utils/network');
+const { downloadImage } = require('../utils/image');
 
 const REFURBISHED_CONDITION_URL = 'https://schema.org/RefurbishedCondition';
 
 const MIN_SANITY_PRICE = 1000; // Anything below 1,000 CLP is likely an error for Apple products in these categories
-
-const MIME_TYPE_MAP = {
-    'image/jpeg': 'jpg',
-    'image/png': 'png',
-    'image/webp': 'webp',
-    'image/gif': 'gif'
-};
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
-
-/**
- * Sniffs the image extension from a buffer's magic numbers.
- * Supports JPEG, PNG, GIF and WebP.
- * @param {Buffer} buffer The image buffer.
- * @returns {string|null} The extension or null if not recognized.
- */
-function sniffImageExtension(buffer) {
-    if (!buffer || buffer.length < 12) return null;
-    
-    // JPEG: FF D8 FF
-    if (buffer[0] === 0xFF && buffer[1] === 0xD8 && buffer[2] === 0xFF) return 'jpg';
-    
-    // PNG: 89 50 4E 47
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4E && buffer[3] === 0x47) return 'png';
-    
-    // GIF: 47 49 46 38 ("GIF8")
-    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) return 'gif';
-    
-    // WebP: RIFF .... WEBP
-    if (buffer.slice(0, 4).toString() === 'RIFF' && buffer.slice(8, 12).toString() === 'WEBP') return 'webp';
-    
-    return null;
-}
 
 /**
  * Monitor for Solotodo deals on Apple products.
@@ -451,62 +419,7 @@ class DealMonitor extends Monitor {
 
             for (const url of candidateUrls) {
                 try {
-                    const stream = got.stream(url, {
-                        ...getSafeGotOptions(),
-                        timeout: { request: 5000 }
-                    });
-
-                    const chunks = [];
-                    let receivedLength = 0;
-                    let contentType = null;
-
-                    await new Promise((resolve, reject) => {
-                        stream.on('response', (res) => {
-                            contentType = res.headers['content-type'];
-                            // Early reject for definitely non-image types
-                            const pureType = contentType ? contentType.split(';')[0].trim() : null;
-                            const isPotentiallyImage = !pureType || 
-                                                       pureType === 'application/octet-stream' || 
-                                                       pureType.startsWith('image/');
-                            
-                            if (!isPotentiallyImage) {
-                                stream.destroy(new Error('Resource is definitely not an image'));
-                            }
-                        });
-                        
-                        stream.on('data', (chunk) => {
-                            receivedLength += chunk.length;
-                            if (receivedLength > MAX_IMAGE_SIZE) {
-                                stream.destroy(new Error('Image too large'));
-                            } else {
-                                chunks.push(chunk);
-                            }
-                        });
-                        
-                        stream.on('end', () => resolve());
-                        stream.on('error', (err) => reject(err));
-                    });
-
-                    const buffer = Buffer.concat(chunks);
-
-                    // Determine extension from Content-Type header first
-                    let extension = '';
-                    if (contentType) {
-                        const pureType = contentType.split(';')[0].trim();
-                        extension = MIME_TYPE_MAP[pureType];
-                    }
-
-                    // If not found by Content-Type (e.g. octet-stream), try sniffing the buffer
-                    if (!extension) {
-                        extension = sniffImageExtension(buffer);
-                    }
-
-                    // Final security check: if we still don't have a recognized image extension, abort.
-                    // This prevents relaying malicious files or SVGs (since they are not in MIME_TYPE_MAP
-                    // and won't match our binary sniffer).
-                    if (!extension) {
-                        throw new Error('Resource content is not a supported image type');
-                    }
+                    const { buffer, extension } = await downloadImage(url);
 
                     const fileName = `product_${product.id}.${extension}`;
                     attachment = new Discord.AttachmentBuilder(buffer, { name: fileName });

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -1,0 +1,107 @@
+const got = require('got');
+const { getSafeGotOptions } = require('./network');
+
+const MIME_TYPE_MAP = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+    'image/gif': 'gif'
+};
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Sniffs the image extension from a buffer's magic numbers.
+ * Supports JPEG, PNG, GIF and WebP.
+ * @param {Buffer} buffer The image buffer.
+ * @returns {string|null} The extension or null if not recognized.
+ */
+function sniffImageExtension(buffer) {
+    if (!buffer || buffer.length < 12) return null;
+    
+    // JPEG: FF D8 FF
+    if (buffer[0] === 0xFF && buffer[1] === 0xD8 && buffer[2] === 0xFF) return 'jpg';
+    
+    // PNG: 89 50 4E 47
+    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4E && buffer[3] === 0x47) return 'png';
+    
+    // GIF: 47 49 46 38 ("GIF8")
+    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) return 'gif';
+    
+    // WebP: RIFF .... WEBP
+    if (buffer.slice(0, 4).toString() === 'RIFF' && buffer.slice(8, 12).toString() === 'WEBP') return 'webp';
+    
+    return null;
+}
+
+/**
+ * Downloads an image from a URL, enforcing size limits and type checks.
+ * @param {string} url The URL of the image to download.
+ * @returns {Promise<{buffer: Buffer, extension: string}>} The image buffer and its extension.
+ * @throws {Error} If the download fails, the image is too large, or the type is invalid.
+ */
+async function downloadImage(url) {
+    const stream = got.stream(url, {
+        ...getSafeGotOptions(),
+        timeout: { request: 5000 }
+    });
+
+    const chunks = [];
+    let receivedLength = 0;
+    let contentType = null;
+
+    await new Promise((resolve, reject) => {
+        stream.on('response', (res) => {
+            contentType = res.headers['content-type'];
+            // Early reject for definitely non-image types
+            const pureType = contentType ? contentType.split(';')[0].trim() : null;
+            const isPotentiallyImage = !pureType || 
+                                       pureType === 'application/octet-stream' || 
+                                       pureType.startsWith('image/');
+            
+            if (!isPotentiallyImage) {
+                stream.destroy(new Error('Resource is definitely not an image'));
+            }
+        });
+        
+        stream.on('data', (chunk) => {
+            receivedLength += chunk.length;
+            if (receivedLength > MAX_IMAGE_SIZE) {
+                stream.destroy(new Error('Image too large'));
+            } else {
+                chunks.push(chunk);
+            }
+        });
+        
+        stream.on('end', () => resolve());
+        stream.on('error', (err) => reject(err));
+    });
+
+    const buffer = Buffer.concat(chunks);
+
+    // Determine extension from Content-Type header first
+    let extension = '';
+    if (contentType) {
+        const pureType = contentType.split(';')[0].trim();
+        extension = MIME_TYPE_MAP[pureType];
+    }
+
+    // If not found by Content-Type (e.g. octet-stream), try sniffing the buffer
+    if (!extension) {
+        extension = sniffImageExtension(buffer);
+    }
+
+    // Final security check
+    if (!extension) {
+        throw new Error('Resource content is not a supported image type');
+    }
+
+    return { buffer, extension };
+}
+
+module.exports = {
+    sniffImageExtension,
+    downloadImage,
+    MIME_TYPE_MAP,
+    MAX_IMAGE_SIZE
+};

--- a/tests/utils/image.test.js
+++ b/tests/utils/image.test.js
@@ -1,0 +1,141 @@
+const { downloadImage, sniffImageExtension, MAX_IMAGE_SIZE } = require('../../src/utils/image');
+const got = require('got');
+
+jest.mock('got', () => {
+    const gotMock = jest.fn();
+    gotMock.stream = jest.fn();
+    return gotMock;
+});
+
+jest.mock('../../src/utils/network', () => ({
+    getSafeGotOptions: jest.fn().mockReturnValue({})
+}));
+
+describe('Image Utility', () => {
+    describe('sniffImageExtension', () => {
+        it('should detect JPEG', () => {
+            const buffer = Buffer.from([0xFF, 0xD8, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            expect(sniffImageExtension(buffer)).toBe('jpg');
+        });
+
+        it('should detect PNG', () => {
+            const buffer = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            expect(sniffImageExtension(buffer)).toBe('png');
+        });
+
+        it('should detect GIF', () => {
+            const buffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            expect(sniffImageExtension(buffer)).toBe('gif');
+        });
+
+        it('should detect WebP', () => {
+            const buffer = Buffer.from('RIFFxxxxWEBP');
+            expect(sniffImageExtension(buffer)).toBe('webp');
+        });
+
+        it('should return null for unknown types', () => {
+            const buffer = Buffer.from('UNKNOWNDATA');
+            expect(sniffImageExtension(buffer)).toBeNull();
+        });
+
+        it('should return null for short buffers', () => {
+            const buffer = Buffer.from('SHORT');
+            expect(sniffImageExtension(buffer)).toBeNull();
+        });
+
+        it('should return null for null/undefined buffer', () => {
+            expect(sniffImageExtension(null)).toBeNull();
+            expect(sniffImageExtension(undefined)).toBeNull();
+        });
+    });
+
+    describe('downloadImage', () => {
+        const mockUrl = 'http://example.com/image.jpg';
+
+        const mockGotStream = (chunks = ['fake-image-data'], headers = { 'content-type': 'image/jpeg' }) => {
+            const stream = new (require('events').EventEmitter)();
+            let destroyed = false;
+            stream.destroy = jest.fn((err) => {
+                destroyed = true;
+                if (err) process.nextTick(() => stream.emit('error', err));
+            });
+            process.nextTick(() => {
+                if (destroyed) return;
+                stream.emit('response', { headers });
+                if (destroyed) return;
+                chunks.forEach(chunk => {
+                    if (!destroyed) stream.emit('data', Buffer.from(chunk));
+                });
+                if (!destroyed) stream.emit('end');
+            });
+            return stream;
+        };
+
+        const mockGotStreamError = (error) => {
+            const stream = new (require('events').EventEmitter)();
+            stream.destroy = jest.fn();
+            process.nextTick(() => {
+                stream.emit('error', error);
+            });
+            return stream;
+        };
+
+        it('should download and return buffer and extension for valid image', async () => {
+            got.stream.mockImplementation(() => mockGotStream(['fake-data'], { 'content-type': 'image/jpeg' }));
+
+            const result = await downloadImage(mockUrl);
+            expect(result.buffer.toString()).toBe('fake-data');
+            expect(result.extension).toBe('jpg');
+        });
+
+        it('should infer extension from buffer if content-type is generic', async () => {
+            // PNG signature
+            const pngData = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D]);
+            got.stream.mockImplementation(() => mockGotStream([pngData], { 'content-type': 'application/octet-stream' }));
+
+            const result = await downloadImage(mockUrl);
+            expect(result.buffer).toEqual(pngData);
+            expect(result.extension).toBe('png');
+        });
+
+        it('should fail if image is too large', async () => {
+            const largeData = Buffer.alloc(MAX_IMAGE_SIZE + 100);
+            
+            got.stream.mockImplementation(() => {
+                const stream = new (require('events').EventEmitter)();
+                let destroyed = false;
+                stream.destroy = jest.fn((err) => {
+                    destroyed = true;
+                    if (err) process.nextTick(() => stream.emit('error', err));
+                });
+                process.nextTick(() => {
+                    if (destroyed) return;
+                    stream.emit('response', { headers: { 'content-type': 'image/jpeg' } });
+                    if (destroyed) return;
+                    stream.emit('data', largeData);
+                });
+                return stream;
+            });
+
+            await expect(downloadImage(mockUrl)).rejects.toThrow('Image too large');
+        });
+
+        it('should fail if content-type is definitely not an image', async () => {
+            got.stream.mockImplementation(() => mockGotStream(['<html></html>'], { 'content-type': 'text/html' }));
+
+            await expect(downloadImage(mockUrl)).rejects.toThrow('Resource is definitely not an image');
+        });
+
+        it('should fail if content is not a supported image type (sniffing fails)', async () => {
+            got.stream.mockImplementation(() => mockGotStream(['random data'], { 'content-type': 'application/octet-stream' }));
+
+            await expect(downloadImage(mockUrl)).rejects.toThrow('Resource content is not a supported image type');
+        });
+        
+        it('should fail on stream error', async () => {
+             got.stream.mockImplementation(() => mockGotStreamError(new Error('Network error')));
+             
+             await expect(downloadImage(mockUrl)).rejects.toThrow('Network error');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Extracted image processing logic from `DealMonitor.js` to a new utility `src/utils/image.js`. This simplifies `DealMonitor` and makes the image downloader reusable.

## Details

- Created `src/utils/image.js` with `downloadImage` and `sniffImageExtension`.
- Moved `MIME_TYPE_MAP` and `MAX_IMAGE_SIZE` to `src/utils/image.js`.
- Updated `DealMonitor.js` to use `downloadImage`.
- Added unit tests in `tests/utils/image.test.js`.

## Related Issues

Fixes #126. Dependency for #128.

## How to Validate

- Run `npm test -- tests/utils/image.test.js` to verify image utility.
- Run `npm test -- tests/monitors/DealMonitor.test.js` to verify `DealMonitor` still works correctly.
- Run `npm run preflight` to ensure everything is fine.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm start