### PR TITLE
feat(monitor): implement grace period for historic low exits (#165)

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -14,6 +14,7 @@ const MIN_DESCRIPTIVE_SLUG_LENGTH = 5;
 const MAX_SKU_LIKE_SLUG_LENGTH = 10;
 
 const DEFAULT_PRICE_TOLERANCE = 500; // 500 CLP tolerance for phantom price spikes
+const DEFAULT_GRACE_PERIOD_HOURS = 12;
 
 // Domains that serve broken or non-standard images for Apple products.
 const BANNED_PICTURE_DOMAINS = [
@@ -73,6 +74,7 @@ module.exports = {
     MIN_DESCRIPTIVE_SLUG_LENGTH,
     MAX_SKU_LIKE_SLUG_LENGTH,
     DEFAULT_PRICE_TOLERANCE,
+    DEFAULT_GRACE_PERIOD_HOURS,
     BANNED_PICTURE_DOMAINS,
     APPLE_PRODUCTS
 };

--- a/tests/monitors/DealMonitor.test.js
+++ b/tests/monitors/DealMonitor.test.js
@@ -253,8 +253,8 @@ describe('DealMonitor', () => {
         expect(monitor.state['1'].pendingExitOffer).toEqual({ date: newDate.toISOString() });
         expect(monitor.state['1'].pendingExitNormal).toEqual({ date: newDate.toISOString() });
         
-        // Advance time by 1 hour for the next check
-        jest.advanceTimersByTime(1000 * 60 * 60);
+        // Advance time by 13 hours for the next check (Default grace period is 12h)
+        jest.advanceTimersByTime(13 * 1000 * 60 * 60);
 
         // 2. Second Check (Confirmation) -> Should CONFIRM exit and update date
         got.mockResolvedValueOnce({

--- a/tests/monitors/DealMonitor_grace_period.test.js
+++ b/tests/monitors/DealMonitor_grace_period.test.js
@@ -1,0 +1,232 @@
+const DealMonitor = require('../../src/monitors/DealMonitor');
+const got = require('got');
+const solotodo = require('../../src/utils/solotodo');
+const Discord = require('discord.js');
+
+jest.mock('got');
+jest.mock('discord.js', () => {
+    const mockChannelInstance = {
+        send: jest.fn().mockResolvedValue({ startThread: jest.fn().mockResolvedValue({}) })
+    };
+    const mockClientInstance = {
+        channels: {
+            cache: {
+                get: jest.fn(() => mockChannelInstance)
+            }
+        }
+    };
+    return {
+        Client: jest.fn(() => mockClientInstance),
+        EmbedBuilder: jest.fn().mockImplementation(() => {
+            const embed = {
+                data: {},
+                setTitle: jest.fn((t) => { embed.data.title = t; return embed; }),
+                setDescription: jest.fn((d) => { embed.data.description = d; return embed; }),
+                addFields: jest.fn((f) => { embed.data.fields = f; return embed; }),
+                setColor: jest.fn((c) => { embed.data.color = c; return embed; }),
+                setTimestamp: jest.fn(() => { embed.data.timestamp = new Date(); return embed; }),
+                setFooter: jest.fn((f) => { embed.data.footer = f; return embed; }),
+                setThumbnail: jest.fn((u) => { embed.data.thumbnail = { url: u }; return embed; })
+            };
+            return embed;
+        }),
+        AttachmentBuilder: jest.fn(),
+        ThreadAutoArchiveDuration: { OneWeek: 10080 }
+    };
+});
+jest.mock('../../src/storage');
+jest.mock('../../src/config');
+jest.mock('../../src/utils/solotodo', () => ({
+    ...jest.requireActual('../../src/utils/solotodo'),
+    getProductHistory: jest.fn().mockResolvedValue([]),
+    getBestPictureUrl: jest.fn().mockImplementation(p => Promise.resolve(p.pictureUrl || p.picture_url)),
+    getAvailableEntities: jest.fn().mockResolvedValue([]),
+    getStores: jest.fn().mockResolvedValue(new Map())
+}));
+jest.mock('../../src/utils/helpers', () => ({
+    sleep: jest.fn().mockResolvedValue()
+}));
+
+describe('DealMonitor Grace Period', () => {
+    let monitor;
+    let mockChannel;
+    let mockClient;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        
+        mockClient = new Discord.Client();
+        mockChannel = mockClient.channels.cache.get('mockDealsChannelId');
+        
+        const monitorConfig = {
+            name: 'Deal',
+            url: 'https://api.com/deals',
+            file: './config/deals.json',
+            gracePeriodHours: 12,
+            priceTolerance: 500
+        };
+
+        monitor = new DealMonitor('Deal', monitorConfig);
+        monitor.client = mockClient;
+    });
+
+    const setupNotificationMocks = (offerPrice = 100000, normalPrice = 100000) => {
+        jest.spyOn(solotodo, 'getAvailableEntities').mockResolvedValue([
+            {
+                active_registry: {
+                    offer_price: String(offerPrice),
+                    normal_price: String(normalPrice),
+                    cell_monthly_payment: null
+                },
+                store: 'https://api.com/stores/1/',
+                external_url: 'https://store.com'
+            }
+        ]);
+        jest.spyOn(solotodo, 'getStores').mockResolvedValue(new Map([['https://api.com/stores/1/', 'Store 1']]));
+    };
+
+    const mockApiResponse = (products) => {
+        const results = products.map(p => ({
+            product_entries: [{
+                product: {
+                    id: p.id,
+                    name: p.name,
+                    slug: p.slug || 'slug',
+                    picture_url: p.picture_url || 'pic.jpg',
+                    specs: { brand_brand_unicode: 'Apple' }
+                },
+                metadata: {
+                    prices_per_currency: [{
+                        currency: solotodo.SOLOTODO_CLP_CURRENCY_URL,
+                        offer_price: p.offerPrice.toString(),
+                        normal_price: p.normalPrice.toString()
+                    }]
+                }
+            }]
+        }));
+        return JSON.stringify({ results });
+    };
+
+    it('should stay in PENDING state during the grace period', async () => {
+        const oldDate = '2024-01-01T00:00:00.000Z';
+        const exitDate = new Date('2024-02-01T10:00:00.000Z');
+        
+        jest.useFakeTimers().setSystemTime(exitDate);
+
+        monitor.state = {
+            '1': { 
+                id: 1, name: 'iPhone', 
+                minOfferPrice: 100000, minOfferDate: oldDate,
+                lastOfferPrice: 100000,
+                minNormalPrice: 100000, minNormalDate: oldDate,
+                lastNormalPrice: 100000
+            }
+        };
+
+        // 1. Initial jump -> Enters PENDING
+        got.mockResolvedValueOnce({ body: mockApiResponse([{ id: 1, name: 'iPhone', offerPrice: 130000, normalPrice: 100000 }]) });
+        await monitor.check();
+        expect(monitor.state['1'].pendingExitOffer).toEqual({ date: exitDate.toISOString() });
+        expect(monitor.state['1'].minOfferDate).toBe(oldDate);
+
+        // 2. 6 hours later (still high) -> Stays PENDING
+        const check2Date = new Date(exitDate.getTime() + 6 * 60 * 60 * 1000);
+        jest.setSystemTime(check2Date);
+        got.mockResolvedValueOnce({ body: mockApiResponse([{ id: 1, name: 'iPhone', offerPrice: 130000, normalPrice: 100000 }]) });
+        await monitor.check();
+        expect(monitor.state['1'].pendingExitOffer).toEqual({ date: exitDate.toISOString() });
+        expect(monitor.state['1'].minOfferDate).toBe(oldDate);
+
+        jest.useRealTimers();
+    });
+
+    it('should silently cancel exit if price returns to low within grace period', async () => {
+        const oldDate = '2024-01-01T00:00:00.000Z';
+        const exitDate = new Date('2024-02-01T10:00:00.000Z');
+        
+        jest.useFakeTimers().setSystemTime(exitDate);
+
+        monitor.state = {
+            '1': { 
+                id: 1, name: 'iPhone', 
+                minOfferPrice: 100000, minOfferDate: oldDate,
+                lastOfferPrice: 130000,
+                pendingExitOffer: { date: exitDate.toISOString() },
+                minNormalPrice: 100000, minNormalDate: oldDate,
+                lastNormalPrice: 100000
+            }
+        };
+
+        // 4 hours later, price returns to low
+        const check2Date = new Date(exitDate.getTime() + 4 * 60 * 60 * 1000);
+        jest.setSystemTime(check2Date);
+        got.mockResolvedValueOnce({ body: mockApiResponse([{ id: 1, name: 'iPhone', offerPrice: 100000, normalPrice: 100000 }]) });
+        
+        await monitor.check();
+
+        // Pending exit should be CLEARED
+        expect(monitor.state['1'].pendingExitOffer).toBeUndefined();
+        // minDate should NOT be updated
+        expect(monitor.state['1'].minOfferDate).toBe(oldDate);
+        // NO notification should be sent
+        expect(mockChannel.send).not.toHaveBeenCalled();
+
+        jest.useRealTimers();
+    });
+
+    it('should confirm exit after grace period expires', async () => {
+        const oldDate = '2024-01-01T00:00:00.000Z';
+        const exitDate = new Date('2024-02-01T10:00:00.000Z');
+        
+        jest.useFakeTimers().setSystemTime(exitDate);
+
+        monitor.state = {
+            '1': { 
+                id: 1, name: 'iPhone', 
+                minOfferPrice: 100000, minOfferDate: oldDate,
+                lastOfferPrice: 130000,
+                pendingExitOffer: { date: exitDate.toISOString() },
+                minNormalPrice: 100000, minNormalDate: oldDate,
+                lastNormalPrice: 100000
+            }
+        };
+
+        // 13 hours later, still high
+        const check2Date = new Date(exitDate.getTime() + 13 * 60 * 60 * 1000);
+        jest.setSystemTime(check2Date);
+        got.mockResolvedValueOnce({ body: mockApiResponse([{ id: 1, name: 'iPhone', offerPrice: 130000, normalPrice: 100000 }]) });
+        
+        await monitor.check();
+
+        // Pending exit should be CLEARED
+        expect(monitor.state['1'].pendingExitOffer).toBeUndefined();
+        // minDate SHOULD be updated to the original exit date
+        expect(monitor.state['1'].minOfferDate).toBe(exitDate.toISOString());
+
+        jest.useRealTimers();
+    });
+
+    it('should trigger BACK_TO_LOW if returning to low AFTER a confirmed exit', async () => {
+        const exitDate = '2024-02-01T10:00:00.000Z';
+        setupNotificationMocks(100000, 100000);
+
+        monitor.state = {
+            '1': { 
+                id: 1, name: 'iPhone', 
+                minOfferPrice: 100000, minOfferDate: exitDate, // Already confirmed exit
+                lastOfferPrice: 130000, // Currently high
+                minNormalPrice: 100000, minNormalDate: exitDate,
+                lastNormalPrice: 130000
+            }
+        };
+
+        got.mockResolvedValueOnce({ body: mockApiResponse([{ id: 1, name: 'iPhone', offerPrice: 100000, normalPrice: 100000 }]) });
+        
+        await monitor.check();
+
+        // SHOULD trigger alert
+        expect(mockChannel.send).toHaveBeenCalled();
+        const sendCall = mockChannel.send.mock.calls[0][0];
+        expect(sendCall.embeds[0].data.description).toContain('Volvió a precios históricos');
+    });
+});


### PR DESCRIPTION
## Summary

This PR introduces a **Grace Period** mechanism to the `DealMonitor`. This feature prevents annoying `BACK TO HISTORIC LOW` alerts when a product becomes briefly unavailable (e.g., card discount disappears for a few hours) by delaying the confirmation of a price exit.

## Details

- **Mechanism**:
    - When a price increase is detected, it enters a `PENDING` state with a timestamp.
    - If the price returns to the historic low *within* the grace period (default: 12h), the exit is cancelled, and **no alert is sent**.
    - The exit is only confirmed if the price remains high after the grace period expires.
- **Configuration**:
    - Added `DEFAULT_GRACE_PERIOD_HOURS` (12h) to `src/utils/constants.js`.
    - Supports per-monitor `gracePeriodHours` setting in configuration.
- **Tests**:
    - Added `tests/monitors/DealMonitor_grace_period.test.js` covering immediate increases, short-term toggles (cancelling), and confirmed exits.
    - Updated `tests/monitors/DealMonitor.test.js` to account for the new default grace period.

## Related Issues

Closes #165

## How to Validate

1. Run `npm test tests/monitors/DealMonitor_grace_period.test.js` to verify the logic.
2. Run `npm run preflight` to ensure all checks pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm start