### PR TITLE
chore(deploy): trigger staging deployment on master branch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [ staging ]
+    branches: [ master ]
   workflow_dispatch:
 
 concurrency:
@@ -14,7 +14,6 @@ jobs:
     name: Deploy to Staging Server
     runs-on: ubuntu-latest
     environment: staging
-    if: github.ref == 'refs/heads/staging'
     permissions:
       contents: read
 


### PR DESCRIPTION
Since the staging branch does not exist, this update allows the staging deployment to trigger on the master branch and removes the skip condition.