### PR TITLE
fix(deploy): use pm2 reload for reliable code updates

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,6 +21,6 @@ npm ci --production
 
 # Restart application via PM2
 echo "[Deploy] Restarting application..."
-pm2 startOrRestart ecosystem.config.js --only "${PM2_APP_NAME:-djs-site-watcher-staging}"
+pm2 reload "${PM2_APP_NAME:-djs-site-watcher-staging}" || pm2 start ecosystem.config.js --only "${PM2_APP_NAME:-djs-site-watcher-staging}"
 
 echo "[Deploy] Deployment successful!"


### PR DESCRIPTION
## Summary

Fixes the deployment issue where `pm2 startOrRestart` fails to pick up code changes if the process configuration hasn't changed.

## Details

Replaces `pm2 startOrRestart` with `pm2 reload` (or fallback to `pm2 start`) in `scripts/deploy.sh`. This ensures a zero-downtime reload that correctly loads the new application code.

## Related Issues

None.

## How to Validate

1. Merge this PR.
2. Trigger a deployment.
3. Verify that the staging application updates to the new code without manual intervention.

## Pre-Merge Checklist

- [x] Tested locally (simulated)