### PR TITLE
ci: depend staging deploy on Node.js CI success

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,11 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Node.js CI"]
+    branches: [master]
+    types:
+      - completed
   workflow_dispatch:
 
 concurrency:
@@ -13,6 +16,7 @@ jobs:
   deploy:
     name: Deploy to Staging Server
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: staging
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Updates the `Deploy to Staging` workflow to trigger only after a successful completion of the `Node.js CI` workflow on the `master` branch.

## Details

- Changed trigger from `push: [master]` to `workflow_run: workflows: [Node.js CI], types: [completed]`.
- Added `if: ${{ github.event.workflow_run.conclusion == 'success' }}` to ensuring deployment only runs if CI passed.

## Related Issues

None.

## How to Validate

1. Merge this PR.
2. Push a change to `master` (or merge another PR).
3. Verify that `Node.js CI` runs first.
4. Verify that `Deploy to Staging` runs *after* CI completes successfully.

## Pre-Merge Checklist

- [x] Verified workflow syntax (visually)