### PR TITLE
fix(site-monitor): add recent hashes logic to prevent cdn flapping

### DIFF
--- a/src/monitors/SiteMonitor.js
+++ b/src/monitors/SiteMonitor.js
@@ -60,6 +60,17 @@ class SiteMonitor extends Monitor {
                     const oldContent = site.lastContent || '';
                     const cleanOldContent = cleanText(oldContent);
                     
+                    if (!Array.isArray(site.recentHashes)) {
+                        site.recentHashes = [site.hash].filter(Boolean);
+                    }
+                    
+                    const isFlapping = site.recentHashes.includes(hash);
+                    
+                    site.recentHashes.push(hash);
+                    if (site.recentHashes.length > 5) {
+                        site.recentHashes.shift();
+                    }
+                    
                     site.lastChecked = new Date().toISOString();
                     site.lastUpdated = new Date().toISOString();
                     site.hash = hash;
@@ -67,7 +78,11 @@ class SiteMonitor extends Monitor {
                     
                     if (cleanOldContent !== content) {
                         hasChanged = true;
-                        this.notify({ site, oldContent, newContent: content, dom });
+                        if (isFlapping) {
+                            logger.info('[Flap Prevention] Suppressed notification for %s. Hash %s was seen recently.', site.url, hash);
+                        } else {
+                            this.notify({ site, oldContent, newContent: content, dom });
+                        }
                     } else {
                         // Silent update (Migration to clean content)
                         hasChanged = true; 
@@ -196,6 +211,7 @@ class SiteMonitor extends Monitor {
             lastUpdated: time.toISOString(),
             hash: hash,
             lastContent: content,
+            recentHashes: [hash],
         };
         
         this.state.push(site);

--- a/src/monitors/SiteMonitor.js
+++ b/src/monitors/SiteMonitor.js
@@ -24,6 +24,7 @@ function cleanText(text) {
 
 const { formatDiscordTimestamp, sanitizeMarkdown } = require('../utils/formatters');
 const CONTEXT_LINES = 3;
+const RECENT_HASH_HISTORY_SIZE = 5;
 
 /**
  * Monitor for changes on arbitrary websites based on CSS selectors.
@@ -67,7 +68,7 @@ class SiteMonitor extends Monitor {
                     const isFlapping = site.recentHashes.includes(hash);
                     
                     site.recentHashes.push(hash);
-                    if (site.recentHashes.length > 5) {
+                    if (site.recentHashes.length > RECENT_HASH_HISTORY_SIZE) {
                         site.recentHashes.shift();
                     }
                     

--- a/src/monitors/SiteMonitor.js
+++ b/src/monitors/SiteMonitor.js
@@ -67,9 +67,7 @@ class SiteMonitor extends Monitor {
                     
                     const isFlapping = site.recentHashes.includes(hash);
                     
-                    const newHistory = site.recentHashes.filter(h => h !== hash);
-                    newHistory.push(hash);
-                    site.recentHashes = newHistory.slice(-RECENT_HASH_HISTORY_SIZE);
+                    site.recentHashes = [...site.recentHashes.filter(h => h !== hash), hash].slice(-RECENT_HASH_HISTORY_SIZE);
                     
                     site.lastChecked = new Date().toISOString();
                     site.lastUpdated = new Date().toISOString();

--- a/src/monitors/SiteMonitor.js
+++ b/src/monitors/SiteMonitor.js
@@ -67,10 +67,9 @@ class SiteMonitor extends Monitor {
                     
                     const isFlapping = site.recentHashes.includes(hash);
                     
-                    site.recentHashes.push(hash);
-                    if (site.recentHashes.length > RECENT_HASH_HISTORY_SIZE) {
-                        site.recentHashes.shift();
-                    }
+                    const newHistory = site.recentHashes.filter(h => h !== hash);
+                    newHistory.push(hash);
+                    site.recentHashes = newHistory.slice(-RECENT_HASH_HISTORY_SIZE);
                     
                     site.lastChecked = new Date().toISOString();
                     site.lastUpdated = new Date().toISOString();

--- a/tests/site-monitor.test.js
+++ b/tests/site-monitor.test.js
@@ -146,6 +146,35 @@ describe('SiteMonitor', () => {
         expect(notifySpy).not.toHaveBeenCalled();
     });
 
+    it('should prevent flapping notifications if hash is in recentHashes', async () => {
+        const notifySpy = jest.spyOn(siteMonitor, 'notify');
+        
+        const site = siteMonitor.state[0];
+        site.hash = 'old-hash';
+        site.recentHashes = ['old-hash', 'flap-hash'];
+        site.lastContent = 'initial content';
+        
+        const response = { body: '<html><head><title>Test Site</title></head><body>flap content</body></html>' };
+        got.mockResolvedValue(response);
+        
+        crypto._mockDigest.mockReturnValue('flap-hash');
+
+        await siteMonitor.check();
+
+        // It should update the state with the flap content and hash
+        expect(site.lastContent).toBe('flap content');
+        expect(site.hash).toBe('flap-hash');
+        
+        // But it should NOT notify because flap-hash is in recentHashes
+        expect(notifySpy).not.toHaveBeenCalled();
+        
+        // However, it SHOULD still save the state to disk
+        expect(storage.write).toHaveBeenCalled();
+        
+        // Also it should have logged the flap prevention
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('[Flap Prevention]'), site.url, 'flap-hash');
+    });
+
     // New tests for parse method
     describe('parse method', () => {
         it('should do nothing and return undefined', () => {


### PR DESCRIPTION
## Summary

This PR addresses an issue where the `SiteMonitor` would incorrectly send alternating notifications (flapping) due to CDN load balancing returning stale/cached page versions.

## Details

It implements a Hash History / Memory approach:
- Adds a `recentHashes` array to the state object to track the last 5 content hashes for each monitored site.
- If a detected change matches a hash recently seen, it silently updates the internal content state but suppresses the Discord notification to prevent spam.
- If the hash is completely new, the standard notification triggers.

## Related Issues

None.

## How to Validate

1. Run tests: `npm run test -- tests/site-monitor.test.js`
2. Verify that flapping tests pass and notifications are appropriately suppressed.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm start